### PR TITLE
update constraints on expressions

### DIFF
--- a/include/pressio/expressions/column.hpp
+++ b/include/pressio/expressions/column.hpp
@@ -60,17 +60,13 @@ auto column(T & operand, IndexType colIndex)
   // note that this works also when T is const-qualified
   // because that qualification carries over to the impl
 
-  constexpr bool constraint = false
-#ifdef PRESSIO_ENABLE_TPL_EIGEN
-    || is_dense_matrix_eigen<T>::value
-#endif
-#ifdef PRESSIO_ENABLE_TPL_TRILINOS
+  constexpr bool constraint =
+    is_dense_matrix_eigen<T>::value
     || is_multi_vector_tpetra<T>::value
-    || is_multi_vector_tpetra_block<T>::value
-#endif
-    ;
-  static_assert(constraint, "pressio::column() currently supported only for "
-		"an Eigen dynamic matrix, a tpetra or tpetra-block multivector");
+    || is_multi_vector_tpetra_block<T>::value;
+  static_assert(constraint,
+      "pressio::column() currently supported only for "
+      "an Eigen dynamic matrix, a tpetra or tpetra-block multivector");
 
   static_assert(Traits< std::remove_const_t<T> >::rank==2,
 		"column can only be applied to a rank-2 object.");

--- a/include/pressio/expressions/diagonal.hpp
+++ b/include/pressio/expressions/diagonal.hpp
@@ -60,16 +60,12 @@ auto diagonal(T & operand)
   // note that this works also when T is const-qualified
   // because that qualification carries over to the impl
 
-  constexpr bool constraint = false
-#ifdef PRESSIO_ENABLE_TPL_KOKKOS
-    || is_dense_matrix_kokkos<T>::value
-#endif
-#ifdef PRESSIO_ENABLE_TPL_EIGEN
-    || is_dense_matrix_eigen<T>::value
-#endif
-    ;
-  static_assert(constraint, "pressio::diagonal() currently supported only for an Eigen dynamic matrix"
-		" or a Kokkos rank-2 View.");
+  constexpr bool constraint =
+    is_dense_matrix_kokkos<T>::value
+    || is_dense_matrix_eigen<T>::value;
+  static_assert(constraint,
+       "pressio::diagonal() currently supported only for an Eigen dynamic matrix"
+       " or a Kokkos rank-2 View.");
   static_assert(Traits<T>::rank==2,
 		"diagonal can only be applied to a rank-2 object.");
 

--- a/include/pressio/expressions/span.hpp
+++ b/include/pressio/expressions/span.hpp
@@ -60,16 +60,11 @@ auto span(T & operand, IndexType startIndex, IndexType extent)
   // note that this works also when T is const-qualified
   // because that qualification carries over to the impl
 
-  constexpr bool constraint = false
-#ifdef PRESSIO_ENABLE_TPL_KOKKOS
-    || is_vector_kokkos<T>::value
-#endif
-#ifdef PRESSIO_ENABLE_TPL_EIGEN
-    || is_dynamic_vector_eigen<T>::value
-#endif
-    ;
-  static_assert(constraint, "pressio::span() currently supported only for an Eigen dynamic vector"
-		" or a Kokkos View.");
+  constexpr bool constraint = is_vector_kokkos<T>::value
+    || is_dynamic_vector_eigen<T>::value;
+  static_assert(constraint,
+       "pressio::span() currently supported only for an Eigen dynamic vector"
+       " or a Kokkos View.");
 
   static_assert(Traits< std::remove_const_t<T> >::rank==1,
 		"span can only be applied to a rank-1 object.");

--- a/include/pressio/expressions/subspan.hpp
+++ b/include/pressio/expressions/subspan.hpp
@@ -62,16 +62,11 @@ auto subspan(T & operand,
   // note that this works also when T is const-qualified
   // because that qualification carries over to the impl
 
-  constexpr bool constraint = false
-#ifdef PRESSIO_ENABLE_TPL_KOKKOS
-    || is_dense_matrix_kokkos<T>::value
-#endif
-#ifdef PRESSIO_ENABLE_TPL_EIGEN
-    || is_dense_matrix_eigen<T>::value
-#endif
-    ;
-  static_assert(constraint, "pressio::subspan() currently supported only for an Eigen dynamic matrix"
-		" or a Kokkos rank-2 View.");
+  constexpr bool constraint = is_dense_matrix_kokkos<T>::value
+    || is_dense_matrix_eigen<T>::value;
+  static_assert(constraint,
+        "pressio::subspan() currently supported only for an Eigen dynamic matrix"
+	" or a Kokkos rank-2 View.");
   static_assert(Traits<T>::rank==2,
 		"subspan can only be applied to a rank-2 object.");
 


### PR DESCRIPTION
remove guards since we don't need them anymore, and also this allows to make the static assert depdenent on the template T since before when all TPLs were off, we have a static assert false that alwys triggers