### PR TITLE
Clean up versioning

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -2,10 +2,10 @@
    :format: html
 
 Configuration and Dependencies
-=============================
+==============================
 
 Configuration
-------------
+-------------
 
 .. tip::
 
@@ -34,16 +34,16 @@ Currently, the list of TPLs supported is shown below:
      - Version Known to Work/run in CI
    * - Eigen
      - Required
-     - 3.3.7
+     - 3.4.0
    * - Trilinos
      - Optional
-     - commit: ef73d14babf6e7556b0420add98cce257ccaa56b
+     - commits: 0dc4553, 5bbda25
    * - MPI
      - Optional
      - --
    * - Kokkos
      - Optional
-     - 3.1.0
+     - 4.4.01
    * - BLAS
      - Optional
      - --
@@ -52,7 +52,7 @@ Currently, the list of TPLs supported is shown below:
      - --
    * - GoogleTest
      - Optional
-     - 1.10.0
+     - 1.14.0
 
 Eigen is the only required dependency because it is the
 default choice for instantiating the ROM data structures

--- a/include/pressio/ops_macros.hpp
+++ b/include/pressio/ops_macros.hpp
@@ -49,9 +49,9 @@
 #ifndef PRESSIOOPS_OPS_MACROS_HPP
 #define PRESSIOOPS_OPS_MACROS_HPP
 
-#define PRESSIO_MAJOR_VERSION 0
-#define PRESSIO_MINOR_VERSION 14
-#define PRESSIO_PATCH_VERSION 0
+#define PRESSIO_OPS_MAJOR_VERSION 0
+#define PRESSIO_OPS_MINOR_VERSION 14
+#define PRESSIO_OPS_PATCH_VERSION 0
 
 // ----------------------------------------
 // compiler version

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(macrosForCreatingUnitTests)
 include(options)
 include(colors)
+include(version)
 
 # ---------------------------------
 # 1. find or get gtest

--- a/tests/cmake/version.cmake
+++ b/tests/cmake/version.cmake
@@ -1,0 +1,14 @@
+
+# versioning
+#=====================================================================
+# adapted from Eigen
+file(READ "${CMAKE_SOURCE_DIR}/include/pressio/ops_macros.hpp" _pressio_ops_macros)
+
+string(REGEX MATCH "define[ \t]+PRESSIO_OPS_MAJOR_VERSION[ \t]+([0-9]+)" _pressio_major_version_match "${_pressio_ops_macros}")
+set(PRESSIO_OPS_MAJOR_VERSION "${CMAKE_MATCH_1}")
+string(REGEX MATCH "define[ \t]+PRESSIO_OPS_MINOR_VERSION[ \t]+([0-9]+)" _pressio_minor_version_match "${_pressio_ops_macros}")
+set(PRESSIO_OPS_MINOR_VERSION "${CMAKE_MATCH_1}")
+string(REGEX MATCH "define[ \t]+PRESSIO_OPS_PATCH_VERSION[ \t]+([0-9]+)" _pressio_patch_version_match "${_pressio_ops_macros}")
+set(PRESSIO_OPS_PATCH_VERSION "${CMAKE_MATCH_1}")
+set(PRESSIO_OPS_VERSION_NUMBER ${PRESSIO_OPS_MAJOR_VERSION}.${PRESSIO_OPS_MINOR_VERSION}.${PRESSIO_OPS_PATCH_VERSION})
+message("${Magenta}>> PRESSIO-OPS: version = ${PRESSIO_OPS_VERSION_NUMBER} ${ColourReset}")

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-Version is defined in lines 52-54 of pressio/include/pressio/ops_macros.hpp
+Version is defined in lines 52-54 of pressio-ops/include/pressio/ops_macros.hpp


### PR DESCRIPTION
This PR:
- Renames the version macros to be specific to pressio-ops (i.e. `PRESSIO_OPS_MAJOR_VERSION`)
- Outputs the current version when building tests
- Updates all TPL versions in the docs to reflect the current state of CI
- Fixes a warning when building the docs